### PR TITLE
Schedule testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Web Audit.html
 
 # for our mac users
 .DS_Store
+
+# sample json file for testing json_parser. remove later.
+!sampleScheduleOutput.json

--- a/test/json_parser.test.js
+++ b/test/json_parser.test.js
@@ -1,80 +1,193 @@
-const json_parser = require('../src/json_parser.js');
+// todo: add module.exports to json_parser for testing, and then use files in './test/mock_parsed_audits/' for testing.
+
+// const json_parser = require('../src/json_parser.js');
 const fs = require('fs');
 
-const cs_sched = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
-const cs_sched2 = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
+// const cs_sched = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
+// const cs_sched2 = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
+const tempSchedule = JSON.parse(fs.readFileSync('./test/mock_parsed_audits/sampleScheduleOutput.json', 'utf-8'));
 
 let schedules = [];
 
-schedules.push(cs_sched);
-schedules.push(cs_sched2);
+// schedules.push(cs_sched);
+// schedules.push(cs_sched2);
+schedules.push(tempSchedule);
 
-// todo: make a custom matcher for schedule.
-// expect.extend({
-//   toBeValidSchedule(schedule) {
-//     const pass = received >= floor && received <= ceiling;
-//     if (pass) {
-//       return {
-//         message: () =>
-//           `expected ${received} not to be within range ${floor} - ${ceiling}`,
-//         pass: true,
-//       };
-//     } else {
-//       return {
-//         message: () =>
-//           `expected ${received} to be within range ${floor} - ${ceiling}`,
-//         pass: false,
-//       };
-//     }
-//   },
-// });
+// runs tests on all items in 'schedules' array.
+for (let index = 0; index < schedules.length; index += 1) {
+  let schedule = schedules[index];
+  
+  // tests that 'schedule' is well formed.
+  test('Ensures that schedule has well formed properties and types.', () => {
+    expect(schedule).toHaveValidScheduleProperties();
+  });
 
-/**
- * Ensures that a given item is a schedule, with correct property format.
- * @param {*} schedule The thing to check.
- */
-let ensureScheduleFormat = schedule => {
-  test('Ensures that schedule has correct property format', () => {
+  // test that 'schedule.completed' is well formed.
+  test('Ensures that schedule.completed has well formed properties and types.', () => {
+    expect(schedule.completed).toHaveValidScheduleCompletedProperties();
+  });
+
+  // test that each item in 'schedule.completed.classes' is well formed.
+  for (let objIndex = 0; objIndex < schedule.completed.classes.length; objIndex += 1) {
+
+    let termObj = schedule.completed.classes[objIndex];
+    test('Ensures that term object has well formed properties and types.', () => {
+      expect(termObj).toHaveValidScheduleCompletedClassesProperties();
+    });
+
+    // test that each item in 'schedule.completed.classes[objIndex].courses' is well formed.
+    for (let courseIdx = 0; courseIdx < termObj.courses.length; courseIdx += 1) {
+
+      let courseObj = termObj.courses[courseIdx];
+      test('Ensures that course object has well formed properties and types.', () => {
+        expect(courseObj).toBeValidCourse();
+      });
+    }
+  }
+
+  // test that 'schedule.scheduled' is well formed.
+  test('Ensures that schedule.scheduled has well formed properties and types.', () => {
+    expect(schedule.scheduled).toHaveValidScheduleScheduledProperties();
+  });
+
+}
+
+// todo: rename 'schedule.scheduled' property to 'schedule.planned' to avoid confusion.
+
+// custom matcher for checking schedule property form.
+expect.extend({
+  toHaveValidScheduleProperties(received) {
 
     // ensure schedule is defined, and is an Object.
-    expect(schedule).toBeDefined();
-    expect(schedule).toBeInstanceOf(Object);
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Object);
 
     // ensure that 'completed' property exists, with correct property format.
-    expect(schedule).toHaveProperty('completed');
-    ensureCompletedFormat(schedule.completed);
+    expect(received).toHaveProperty('completed');
 
     // ensure that 'scheduled' property exists, is defined, and is an Array.
-    expect(schedule).toHaveProperty('scheduled');
-    ensureScheduledFormat(schedule.scheduled);
-  });
-}
+    expect(received).toHaveProperty('scheduled');
 
-/**
- * Ensures that a given item is a completed, with correct property format.
- * @param {*} completed The thing to check.
- */
-let ensureCompletedFormat = completed => {
-  test('Ensures that completed has correct property format', () => {
+    return {
+      message: () => `expected ${received} not to have valid schedule properties.`,
+      pass: true,
+    };
+  },
+});
+
+// custom matcher for checking schedule.completed property form.
+expect.extend({
+  toHaveValidScheduleCompletedProperties(received) {
+
+    // received is 'schedule.completed'.
+
+    // ensure that schedule.completed is defined, and is an Object.
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Object);
+
+    // ensure that schedule.completed.classes field exists, with correct property format.
+    expect(received).toHaveProperty('classes');
+    expect(received.classes).toBeDefined();
+    expect(received.classes).toBeInstanceOf(Array);
+
+    return {
+      message: () => `expected ${received} not to have valid schedule.completed properties.`,
+      pass: true,
+    };
+  },
+});
+
+// custom matcher for checking schedule.completed.classes property form.
+expect.extend({
+  toHaveValidScheduleCompletedClassesProperties(received) {
+
+    // received.classes should be an Array of Objects with termId and courses properties.
+    // yeah, I know it doesn't make sense for received.classes to not be an array of classes. Sorry.
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Object);
     
-    // ensures that completed is defined, and is an Object.
-    expect(schedule.completed).toBeDefined();
-    expect(schedule.completed).toBeInstanceOf(Object);
-  });
-}
+    // ensures received has property 'termId', that is a number that matches 20xx[1-6]0.
+    expect(received).toHaveProperty('termId');
+    expect(received.termId).toBeDefined();
+    // expect(received.termId).toBeInstanceOf(Number);
+    expect("" + received.termId).toMatch(/^20\d\d[1-6]0$/);
+    
+    // ensures received has property 'courses', that is an Array of courses.
+    expect(received).toHaveProperty('courses');
+    expect(received.courses).toBeDefined();
+    expect(received.courses).toBeInstanceOf(Array);
 
-/**
- * Ensures that a given item is a scheduled, with correct property format.
- * @param {*} scheduled The thing to check.
- */
-let ensureScheduledFormat = scheduled => {
-  test('Ensures that scheduled has correct property format', () => {
+    return {
+      message: `expected ${received} to not have valid schedule.completed.classes properties.`,
+      pass: true,
+    };
+  },
+});
 
-    // ensures schedule is defined, and is an array.
-    expect(schedule.completed).toBeDefined();
-    expect(schedule.completed).toBeInstanceOf(Array);
+// custom matcher to ensure received is a valid course.
+expect.extend({
+  toBeValidCourse(received) {
 
-    // todo: check that each of the completed classes are also valid classes.
-  });
-}
+    // ensure that received is an Object.
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Object);
 
+    // todo: add the name property to list of tests.
+    // ensure that received contains the following properties, and that they are all defined.
+    let props = ['hon', 'subject', 'classId', 'credithours', 'season', 'year', 'termId'];
+    for (let i = 0; i < props.length; i += 1) {
+      expect(received).toHaveProperty(props[i]);
+      expect(received[props[i]]).toBeDefined();
+    }
+
+    // ensure the properties' values are well formed.
+    expect(received.subject).toMatch(/^[A-Z]{2,4}$/);
+    expect(received.classId).toMatch(/^[\d]{4}$/);
+    expect(received.credithours).toMatch(/^[\d]\.00/);
+    expect(received.season).toMatch(/FL|SP|S1|S2|SM/);
+    expect(received.year).toMatch(/^\d\d$/);
+    expect(received.termId).toMatch(/^20\d\d[1-6]0$/);
+    // expect(received.name).toBeInstanceOf(String);
+    
+    return {
+      message: () => `expected ${received} not to have valid course properties`,
+      pass: true,
+    };
+  },
+});
+
+// custom matcher for checking schedule.scheduled property form.
+expect.extend({
+  toHaveValidScheduleScheduledProperties(received) {
+
+    // received is 'schedule.scheduled'.
+
+    // ensure that received is defined, and is an Array.
+    expect(received).toBeDefined();
+    expect(received).toBeInstanceOf(Array);
+
+    // ensure that each item in received is an Array of courses.
+    for (let i = 0; i < received.length; i += 1) {
+
+      let item = received[i];
+
+      expect(item).toBeDefined();
+      expect(item).toBeInstanceOf(Array);
+
+      // we should never have more than 4 courses in a semester.
+      expect(item.length).toBeLessThanOrEqual(4);
+      
+      for (let j = 0; j < item.length; j += 1) {
+        let itemCourse = item[j];
+
+        expect(itemCourse).toBeDefined();
+        // expect(itemCourse).toBeInstanceOf(String);
+      }
+    }
+
+    return {
+      message: () => `expected ${received} not to have valid schedule.scheduled properties.`,
+      pass: true,
+    };
+  },
+});

--- a/test/json_parser.test.js
+++ b/test/json_parser.test.js
@@ -1,0 +1,80 @@
+const json_parser = require('../src/json_parser.js');
+const fs = require('fs');
+
+const cs_sched = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
+const cs_sched2 = json_parser.toSchedule(fs.readFileSync('./test/mock_parsed_audits/cs_schedule.json', 'utf-8'));
+
+let schedules = [];
+
+schedules.push(cs_sched);
+schedules.push(cs_sched2);
+
+// todo: make a custom matcher for schedule.
+// expect.extend({
+//   toBeValidSchedule(schedule) {
+//     const pass = received >= floor && received <= ceiling;
+//     if (pass) {
+//       return {
+//         message: () =>
+//           `expected ${received} not to be within range ${floor} - ${ceiling}`,
+//         pass: true,
+//       };
+//     } else {
+//       return {
+//         message: () =>
+//           `expected ${received} to be within range ${floor} - ${ceiling}`,
+//         pass: false,
+//       };
+//     }
+//   },
+// });
+
+/**
+ * Ensures that a given item is a schedule, with correct property format.
+ * @param {*} schedule The thing to check.
+ */
+let ensureScheduleFormat = schedule => {
+  test('Ensures that schedule has correct property format', () => {
+
+    // ensure schedule is defined, and is an Object.
+    expect(schedule).toBeDefined();
+    expect(schedule).toBeInstanceOf(Object);
+
+    // ensure that 'completed' property exists, with correct property format.
+    expect(schedule).toHaveProperty('completed');
+    ensureCompletedFormat(schedule.completed);
+
+    // ensure that 'scheduled' property exists, is defined, and is an Array.
+    expect(schedule).toHaveProperty('scheduled');
+    ensureScheduledFormat(schedule.scheduled);
+  });
+}
+
+/**
+ * Ensures that a given item is a completed, with correct property format.
+ * @param {*} completed The thing to check.
+ */
+let ensureCompletedFormat = completed => {
+  test('Ensures that completed has correct property format', () => {
+    
+    // ensures that completed is defined, and is an Object.
+    expect(schedule.completed).toBeDefined();
+    expect(schedule.completed).toBeInstanceOf(Object);
+  });
+}
+
+/**
+ * Ensures that a given item is a scheduled, with correct property format.
+ * @param {*} scheduled The thing to check.
+ */
+let ensureScheduledFormat = scheduled => {
+  test('Ensures that scheduled has correct property format', () => {
+
+    // ensures schedule is defined, and is an array.
+    expect(schedule.completed).toBeDefined();
+    expect(schedule.completed).toBeInstanceOf(Array);
+
+    // todo: check that each of the completed classes are also valid classes.
+  });
+}
+

--- a/test/mock_parsed_audits/sampleScheduleOutput.json
+++ b/test/mock_parsed_audits/sampleScheduleOutput.json
@@ -1,0 +1,308 @@
+{
+  "completed": {
+    "classes": [
+      {
+        "termId": 201860,
+        "courses": [
+          {
+            "hon": false,
+            "subject": "MATH",
+            "classId": "1341",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "MATH",
+            "classId": "1342",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "BIOL",
+            "classId": "1111",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "BIOL",
+            "classId": "1112",
+            "credithours": "1.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "BIOL",
+            "classId": "1113",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "BIOL",
+            "classId": "1114",
+            "credithours": "1.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "ENGW",
+            "classId": "1111",
+            "credithours": "8.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "1990",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "ECON",
+            "classId": "1115",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "ECON",
+            "classId": "1116",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "HIST",
+            "classId": "1110",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "MATH",
+            "classId": "2280",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "PHYS",
+            "classId": "1151",
+            "credithours": "3.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "PHYS",
+            "classId": "1152",
+            "credithours": "1.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "PHYS",
+            "classId": "1153",
+            "credithours": "1.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          },
+          {
+            "hon": false,
+            "subject": "PSYC",
+            "classId": "1101",
+            "credithours": "4.00",
+            "season": "S2",
+            "year": "18",
+            "termId": "201860"
+          }
+        ]
+      },
+      {
+        "termId": 201910,
+        "courses": [
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "1200",
+            "credithours": "1.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": true,
+            "subject": "CS",
+            "classId": "1800",
+            "credithours": "4.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": true,
+            "subject": "CS",
+            "classId": "1802",
+            "credithours": "1.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2500",
+            "credithours": "4.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2501",
+            "credithours": "1.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": false,
+            "subject": "MATH",
+            "classId": "2331",
+            "credithours": "4.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": true,
+            "subject": "PHIL",
+            "classId": "1145",
+            "credithours": "4.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          },
+          {
+            "hon": true,
+            "subject": "HONR",
+            "classId": "1102",
+            "credithours": "1.00",
+            "season": "FL",
+            "year": "18",
+            "termId": "201910"
+          }
+        ]
+      },
+      {
+        "termId": 201930,
+        "courses": [
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2510",
+            "credithours": "4.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2511",
+            "credithours": "1.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2800",
+            "credithours": "4.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "2801",
+            "credithours": "1.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "3200",
+            "credithours": "4.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          },
+          {
+            "hon": false,
+            "subject": "CS",
+            "classId": "3950",
+            "credithours": "2.00",
+            "season": "SP",
+            "year": "19",
+            "termId": "201930"
+          }
+        ]
+      }
+    ]
+  },
+  "scheduled": [
+    [
+      "CS1210",
+      "CS3700",
+      "CS3800",
+      "THTR1170"
+    ],
+    [
+      "DS2000",
+      "CS3500",
+      "CS3000"
+    ],
+    [
+      "CS4500",
+      "CS4400"
+    ]
+  ]
+}


### PR DESCRIPTION
Added sample tests for json_parser.js.

Note that official tests cannot be added until previous PR is merged, and then json_parser is converted to use module.exports so that functions can be loaded in json_parser.test.js.

Also note that the tests added here do not yet account for the 'name' field in course objects, which will be changed (post merge). 

Also note that a few fields are different in this older version of the code, and so a few property tests were left commented out.

JSON input files have not yet been added to the repository, but will be expected under directory './test/mock_parsed_audits/'

Upon completion of module.exports integration into json_parser.js, the tests can be updated and sampleScheduleOutput.json can be removed.